### PR TITLE
Update PHP version requirements

### DIFF
--- a/PorticoExportPlugin.inc.php
+++ b/PorticoExportPlugin.inc.php
@@ -149,7 +149,7 @@ class PorticoExportPlugin extends ImportExportPlugin {
 						new League\Flysystem\PhpseclibV2\SftpConnectionProvider(
 							$credentials['hostname'],
 							$credentials['username'],
-							$credentials['password'],
+							$credentials['password']
 						),
 						$credentials['path']
 					);

--- a/version.xml
+++ b/version.xml
@@ -13,6 +13,6 @@
 <version>
 	<application>portico</application>
 	<type>plugins.importexport</type>
-	<release>1.1.0.2</release>
-	<date>2021-02-25</date>
+	<release>1.1.0.3</release>
+	<date>2021-07-19</date>
 </version>


### PR DESCRIPTION
At least the trailing comma in this constructor requires 7.3:
https://github.com/pkp/portico/blob/026559913ad47c1315d3c830d9484e86049858fe/PorticoExportPlugin.inc.php#L152
