### PR TITLE
Galleys: Collect galleys where data is not loaded

### DIFF
--- a/PorticoExportPlugin.php
+++ b/PorticoExportPlugin.php
@@ -249,7 +249,10 @@ class PorticoExportPlugin extends ImportExportPlugin
 
                     // add galleys
                     $fileService = app()->get('file');
-                    $galleys = $article->getData('galleys') ?? [];
+                    $galleys = Repo::galley()->getCollector()
+                        ->filterByPublicationIds([$article->getData('currentPublicationId')])
+                        ->getMany()
+                        ->toArray();
                     foreach ($galleys as $galley) {
                         $submissionFileId = $galley->getData('submissionFileId');
                         $submissionFile = $submissionFileId ? Repo::submissionFile()->get($submissionFileId) : null;


### PR DESCRIPTION
We've come across a recent issue whereby galleys were not being included which seems to be with a compatibility issue with 3.5.

I've added instead swapped to use the Repo from similar to how the deprecated getGalleys function does things which seemed to fix things in my testing